### PR TITLE
#92 Скрыты пустые категории на странице статистики

### DIFF
--- a/client/src/components/StatisticsPage/StatisticsPage.jsx
+++ b/client/src/components/StatisticsPage/StatisticsPage.jsx
@@ -158,7 +158,7 @@ export default class StatisticsPage extends React.Component {
         });
 
         const groupsArray = [];
-        groups.forEach((children, label) => groupsArray.push({ children, label }));
+        groups.forEach((children, label) => children.length !== 0 && groupsArray.push({ children, label }));
         return groupsArray;
     }
 


### PR DESCRIPTION
Пустые категории скрыты внизу (прогресс бары) и наверху (легенда к чарту).