### PR TITLE
Перенес главное меню вниз

### DIFF
--- a/client/src/components/SettingsPage/SettingsPage.scss
+++ b/client/src/components/SettingsPage/SettingsPage.scss
@@ -14,6 +14,7 @@
   .cardList {
     text-align: left;
     height: calc(100vh - 160px);
+    margin-bottom: 10px;
     overflow-y: auto;
   }
 }

--- a/client/src/components/StatisticsPage/StatisticsPage.scss
+++ b/client/src/components/StatisticsPage/StatisticsPage.scss
@@ -6,7 +6,7 @@
 
         .control-panel {
             position: fixed;
-            top: 52px;
+            top: 0;
             background-color: #fff;
             z-index: 10;
             width: 100%;

--- a/client/src/components/app.scss
+++ b/client/src/components/app.scss
@@ -23,13 +23,12 @@ html, body {
     margin: 0 auto;
     font-size: 1.02em;
     height: calc(99vh - 52px);
-    padding-top: 52px;
   }
 
   .main-header {
     position: fixed;
     z-index: 10;
-    top: 0;
+    bottom: 0;
     left: 0;
     width: 100vw;
     background-color: #fff;


### PR DESCRIPTION
Перенес главное меню вниз.
Мне не очень нравится, что на мобилках, когда открывается клавиатура, меню поднимается над клавиатурой из-за того, что у нас высота приложения привязана к высоте окна, а менюшка зафиксина отображаться в самом низу.